### PR TITLE
Prevent import extensions where unnecessary.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     plugins: ['prettier'],
 
     rules: {
+        'import/extensions': ['error', 'never'],
         'prettier/prettier': 'error',
     },
 


### PR DESCRIPTION
Documentation for the `import/extensions` rule is here: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md